### PR TITLE
Introduce `publish` workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Publish
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org/
+          cache: npm
+      - run: npm ci
+      - run: npm test
+      - run: |
+          echo "Publishing $TAG_NAME"
+          npm version ${TAG_NAME} --git-tag-version=false
+        env:
+          TAG_NAME: ${{github.event.release.tag_name}}
+      - run: npm whoami; npm --ignore-scripts publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
Fixes: https://github.com/github/markdownlint-github/issues/7

I am following the steps in [TheHub: Publishing npm packages](https://thehub.github.com/epd/engineering/dev-practicals/frontend/publishing-npm-packages/) so the package is automatically published upon creation of release.