### PR TITLE
Allow exceptions to be configured

### DIFF
--- a/no-generic-link-text.js
+++ b/no-generic-link-text.js
@@ -19,9 +19,15 @@ module.exports = {
   tags: ["accessibility", "links"],
   function: function GH002(params, onError) {
     // markdown syntax
-    const allBannedLinkTexts = bannedLinkText.concat(
+    let bannedLinkTexts = bannedLinkText.concat(
       params.config.additional_banned_texts || []
     );
+    const exceptions = params.config.exceptions || [];
+    if (exceptions.length > 0) {
+      bannedLinkTexts = bannedLinkTexts.filter(
+        (text) => !exceptions.includes(text)
+      );
+    }
     const inlineTokens = params.tokens.filter((t) => t.type === "inline");
     for (const token of inlineTokens) {
       const { children } = token;
@@ -35,7 +41,7 @@ module.exports = {
           linkText = "";
         } else if (type === "link_close") {
           inLink = false;
-          if (allBannedLinkTexts.includes(stripAndDowncaseText(linkText))) {
+          if (bannedLinkTexts.includes(stripAndDowncaseText(linkText))) {
             onError({
               lineNumber: child.lineNumber,
               detail: `For link: ${linkText}`,

--- a/test/no-generic-link-text.test.js
+++ b/test/no-generic-link-text.test.js
@@ -75,5 +75,17 @@ describe("GH002: No Generic Link Text", () => {
 
       expect(failedRules).toHaveLength(1);
     });
+
+    test("exceptions can be configured", async () => {
+      const results = await runTest(
+        ["[Link](primer.style/components/Link)"],
+        noGenericLinkTextRule,
+        { exceptions: ["link"] }
+      );
+
+      for (const result of results) {
+        expect(result).not.toBeDefined();
+      }
+    });
   });
 });


### PR DESCRIPTION
In some projects, the defaults we have configured for the `no-generic-link-text` rule do not make sense. We should allow exceptions to be configured.

With this update, exceptions can be configured for the `no-generic-link-text` rule like so:

```.js
"no-generic-link-text": { "exceptions": ["link"] } 
```

In particular, this need surfaced in the Primer ViewComponents repo, where we don't want to flag `[Link](primer.style/view_components/components/link)` where `Link` refers to a component, rather than a generic text. We determined that allowing exceptions is the better route to go for now.