### PR TITLE
Update alt text rule to flag `image` or `Image`

### DIFF
--- a/src/rules/no-default-alt-text.js
+++ b/src/rules/no-default-alt-text.js
@@ -1,15 +1,18 @@
 // Regex to match alt text that is the same as the default image filename
 // e.g. "Screen Shot 2020-10-20 at 2 52 27 PM"
 // e.g. "Screenshot 2020-10-20 at 2 52 27 PM"
-const altTextRegex =
+const defaultMacOsScreenshotMarkdownRegex =
   /^Screen ?[S|s]hot \d{4}-\d{2}-\d{2} at \d \d{2} \d{2} [A|P]M$/gi;
-const altTextTagRegex =
+const imageMarkdownRegex = /^image$/i;
+
+const defaultMacOsScreenshotHtmlRegex =
   /alt="Screen ?[S|s]hot \d{4}-\d{2}-\d{2} at \d \d{2} \d{2} [A|P]M"/gi;
+const imageHtmlRegex = /alt="image"/i;
 
 module.exports = {
   names: ["GH001", "no-default-alt-text"],
   description:
-    "Images should not use the MacOS default screenshot filename as alternate text (alt text). If you have not changed this file, try merging main with your branch. For more information see: https://primer.style/design/accessibility/alternative-text-for-images",
+    "Images should set meaningful alternative text (alt text), and not use the macOS default screenshot filename or `Image`.",
   information: new URL(
     "https://github.com/github/markdownlint-github/blob/main/docs/rules/GH001-no-default-alt-text.md"
   ),
@@ -20,7 +23,10 @@ module.exports = {
     for (const token of inlineTokens) {
       const imageTokens = token.children.filter((t) => t.type === "image");
       for (const image of imageTokens) {
-        if (image.content.match(altTextRegex)) {
+        if (
+          image.content.match(defaultMacOsScreenshotMarkdownRegex) ||
+          image.content.match(imageMarkdownRegex)
+        ) {
           onError({
             lineNumber: image.lineNumber,
             detail: `For image: ${image.content}`,
@@ -32,7 +38,10 @@ module.exports = {
     // html syntax
     let lineNumber = 1;
     for (const line of params.lines) {
-      if (line.match(altTextTagRegex)) {
+      if (
+        line.match(defaultMacOsScreenshotHtmlRegex) ||
+        line.match(imageHtmlRegex)
+      ) {
         onError({
           lineNumber,
           detail: `For image: ${line}`,

--- a/test/no-default-alt-text.test.js
+++ b/test/no-default-alt-text.test.js
@@ -33,6 +33,8 @@ describe("GH001: No Default Alt Text", () => {
         "![ScreenShot 2022-06-26 at 7 41 30 PM](https://user-images.githubusercontent.com/abcdef.png)",
         "![Screen shot 2022-06-26 at 7 41 30 PM](https://user-images.githubusercontent.com/abcdef.png)",
         "![Screenshot 2022-06-26 at 7 41 30 PM](https://user-images.githubusercontent.com/abcdef.png)",
+        "![image](https://user-images.githubusercontent.com/abcdef.png)",
+        "![Image](https://user-images.githubusercontent.com/abcdef.png)",
       ];
 
       const results = await runTest(strings, altTextRule);
@@ -42,7 +44,7 @@ describe("GH001: No Default Alt Text", () => {
         .flat()
         .filter((name) => !name.includes("GH"));
 
-      expect(failedRules).toHaveLength(4);
+      expect(failedRules).toHaveLength(6);
       for (const rule of failedRules) {
         expect(rule).toBe("no-default-alt-text");
       }
@@ -54,6 +56,8 @@ describe("GH001: No Default Alt Text", () => {
         '<img alt="ScreenShot 2022-06-26 at 7 41 30 PM" src="https://user-images.githubusercontent.com/abcdef.png">',
         '<img alt="Screen shot 2022-06-26 at 7 41 30 PM" src="https://user-images.githubusercontent.com/abcdef.png">',
         '<img alt="Screenshot 2022-06-26 at 7 41 30 PM" src="https://user-images.githubusercontent.com/abcdef.png">',
+        '<img alt="Image" src="https://user-images.githubusercontent.com/abcdef.png">',
+        '<img alt="image" src="https://user-images.githubusercontent.com/abcdef.png">',
       ];
 
       const results = await runTest(strings, altTextRule);
@@ -63,7 +67,7 @@ describe("GH001: No Default Alt Text", () => {
         .flat()
         .filter((name) => !name.includes("GH"));
 
-      expect(failedRules).toHaveLength(4);
+      expect(failedRules).toHaveLength(6);
       for (const rule of failedRules) {
         expect(rule).toBe("no-default-alt-text");
       }
@@ -78,13 +82,13 @@ describe("GH001: No Default Alt Text", () => {
       const results = await runTest(strings, altTextRule);
 
       expect(results[0].ruleDescription).toMatch(
-        /Images should not use the MacOS default screenshot filename as alternate text/
+        "Images should set meaningful alternative text (alt text), and not use the macOS default screenshot filename or `Image`."
       );
       expect(results[0].errorDetail).toBe(
         "For image: Screen Shot 2022-06-26 at 7 41 30 PM"
       );
       expect(results[1].ruleDescription).toMatch(
-        /Images should not use the MacOS default screenshot filename as alternate text/
+        "Images should set meaningful alternative text (alt text), and not use the macOS default screenshot filename or `Image`."
       );
       expect(results[1].errorDetail).toBe(
         'For image: <img alt="Screen Shot 2022-06-26 at 7 41 30 PM" src="https://user-images.githubusercontent.com/abcdef.png">'


### PR DESCRIPTION
**After https://github.com/github/markdownlint-github/pull/26 is merged, rebase and  merge.**

Fixes: https://github.com/github/markdownlint-github/issues/23

This PR updates the `no-default-alt-text` rule, which currently only flags the macOS default screenshot name, to flag `Image` and `image` as alt text. Accordingly, it updates the lint rule description to be more broad.