### PR TITLE
Update regex logic for flagging alt text

### DIFF
--- a/src/rules/no-default-alt-text.js
+++ b/src/rules/no-default-alt-text.js
@@ -1,12 +1,14 @@
 // Regex to match alt text that is the same as the default image filename
 // e.g. "Screen Shot 2020-10-20 at 2 52 27 PM"
 // e.g. "Screenshot 2020-10-20 at 2 52 27 PM"
+// e.g. "Clean Shot 2020-10-20 @45x"
+// e.g. "image"
 const defaultMacOsScreenshotMarkdownRegex =
-  /^Screen ?[S|s]hot \d{4}-\d{2}-\d{2} at \d \d{2} \d{2} [A|P]M$/gi;
+  /^(Screen|Clean) ?[S|s]hot \d{4}-\d{2}-\d{2}/gi;
 const imageMarkdownRegex = /^image$/i;
 
 const defaultMacOsScreenshotHtmlRegex =
-  /alt="Screen ?[S|s]hot \d{4}-\d{2}-\d{2} at \d \d{2} \d{2} [A|P]M"/gi;
+  /alt="(Screen|Clean) ?[S|s]hot \d{4}-\d{2}-\d{2}/gi;
 const imageHtmlRegex = /alt="image"/i;
 
 module.exports = {

--- a/test/no-default-alt-text.test.js
+++ b/test/no-default-alt-text.test.js
@@ -33,6 +33,7 @@ describe("GH001: No Default Alt Text", () => {
         "![ScreenShot 2022-06-26 at 7 41 30 PM](https://user-images.githubusercontent.com/abcdef.png)",
         "![Screen shot 2022-06-26 at 7 41 30 PM](https://user-images.githubusercontent.com/abcdef.png)",
         "![Screenshot 2022-06-26 at 7 41 30 PM](https://user-images.githubusercontent.com/abcdef.png)",
+        "![Clean Shot 2022-06-26 at 7 41 30 PM](https://user-images.githubusercontent.com/abcdef.png)",
         "![image](https://user-images.githubusercontent.com/abcdef.png)",
         "![Image](https://user-images.githubusercontent.com/abcdef.png)",
       ];
@@ -44,7 +45,7 @@ describe("GH001: No Default Alt Text", () => {
         .flat()
         .filter((name) => !name.includes("GH"));
 
-      expect(failedRules).toHaveLength(6);
+      expect(failedRules).toHaveLength(7);
       for (const rule of failedRules) {
         expect(rule).toBe("no-default-alt-text");
       }
@@ -56,6 +57,7 @@ describe("GH001: No Default Alt Text", () => {
         '<img alt="ScreenShot 2022-06-26 at 7 41 30 PM" src="https://user-images.githubusercontent.com/abcdef.png">',
         '<img alt="Screen shot 2022-06-26 at 7 41 30 PM" src="https://user-images.githubusercontent.com/abcdef.png">',
         '<img alt="Screenshot 2022-06-26 at 7 41 30 PM" src="https://user-images.githubusercontent.com/abcdef.png">',
+        '<img alt="Clean Shot 2022-06-26 at 7 41 30 PM" src="https://user-images.githubusercontent.com/abcdef.png">',
         '<img alt="Image" src="https://user-images.githubusercontent.com/abcdef.png">',
         '<img alt="image" src="https://user-images.githubusercontent.com/abcdef.png">',
       ];
@@ -67,7 +69,7 @@ describe("GH001: No Default Alt Text", () => {
         .flat()
         .filter((name) => !name.includes("GH"));
 
-      expect(failedRules).toHaveLength(6);
+      expect(failedRules).toHaveLength(7);
       for (const rule of failedRules) {
         expect(rule).toBe("no-default-alt-text");
       }


### PR DESCRIPTION
This PR adds support to flag additional file formats.