### PR TITLE
Enforce asterisk-style unordered lists

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,8 @@ Thank you for your interest in contributing.
 
 Depending on your needs, you may have one of two development paths:
 
-- via integrating with an existing usage (ideal for modifying the interface of our rules)
-- via unit testing (ideal for adding a new rule)
+* via integrating with an existing usage (ideal for modifying the interface of our rules)
+* via unit testing (ideal for adding a new rule)
 
 For that reason we've included two paths to develop. Feel free to use either, or both.
 
@@ -32,8 +32,8 @@ It may be useful to work on this in tandem with a codebase that uses the rules. 
     If you go to the `node_modules` directory in your codebase and try to navigate into the package, you'll notice that whatever changes you make in your local development directory will be reflected in the codebase.
 
 3. Reset symlinks at any time by reversing the steps via `npm unlink`.
-    - in your codebase: `npm unlink @github/markdownlint-github`
-    - in this directory: `npm unlink`
+    * in your codebase: `npm unlink @github/markdownlint-github`
+    * in this directory: `npm unlink`
 
 ### Unit and Interface Testing
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ See opinions codified in [index.js](./index.js).
 
 The following are custom rules defined in this plugin.
 
-- [**GH001** _no-default-alt-text_](./docs/rules/GH001-no-default-alt-text.md)
-- [**GH002** _no-generic-link-text_](./docs/rules/GH002-no-generic-link-text.md)
+* [**GH001** _no-default-alt-text_](./docs/rules/GH001-no-default-alt-text.md)
+* [**GH002** _no-generic-link-text_](./docs/rules/GH002-no-generic-link-text.md)
 
 See [`markdownlint` rules](https://github.com/DavidAnson/markdownlint#rules--aliases) for documentation on rules pulled in from `markdownlint`.
 
@@ -29,11 +29,11 @@ See [`markdownlint` rules](https://github.com/DavidAnson/markdownlint#rules--ali
 
 2. Install packages.
 
-    - ```bash
-      npm install -D markdownlint-cli2 # if updating existing package, check for updates
-      npm install -D @github/markdownlint-github [--@github:registry=https://registry.npmjs.org]
-      npm install -D markdownlint-cli2-formatter-pretty
-      ```
+    ```bash
+    npm install -D markdownlint-cli2 # if updating existing package, check for updates
+    npm install -D @github/markdownlint-github [--@github:registry=https://registry.npmjs.org]
+    npm install -D markdownlint-cli2-formatter-pretty
+    ```
 
 3. Add/modify your linting script in `package.json`.
 

--- a/style/accessibility.json
+++ b/style/accessibility.json
@@ -8,5 +8,7 @@
     "no-space-in-links": false,
     "ol-prefix": "ordered",
     "single-h1": true,
-    "ul-style": true
+    "ul-style": {
+        "style": "asterisk"
+    }
 }

--- a/test/usage.test.js
+++ b/test/usage.test.js
@@ -19,7 +19,9 @@ describe("usage", () => {
         "no-emphasis-as-header": true,
         "no-heading-increment": true,
         "no-generic-link-text": true,
-        "ul-style": true,
+        "ul-style": {
+          style: "asterisk",
+        },
         default: true,
         "no-inline-html": false,
         "no-bare-urls": false,


### PR DESCRIPTION
Asterisk style lists (ie, ` * item`) are preferred over other list styles because asterisks are most likely to be read out by screen readers. For example, given the following Markdown:

```md
Fruits:

* Apple
* Banana
* Pear
```

VoiceOver on my machine reads:

> Fruits {pause} star apple star banana star pear

Whereas with the following Markdown:

```md
Fruits:

- Apple
- Banana
- Pear
```

VoiceOver reads:

> Fruits {pause} apple {pause} banana {pause} pear

This makes it much less obvious that what is being read is actually a list.

---

The current configuration enables the `ul-style` rule, but by default this rule has the `style` parameter set to `consistent`. This ensures that the list style is consistent across the whole file, based on the first encountered list item. What we really want is `asterisk`, which ensures that the list delimiter is always the `*` character.