### PR TITLE
Fix typo in `heading-increment` rule name

### DIFF
--- a/style/accessibility.json
+++ b/style/accessibility.json
@@ -4,7 +4,7 @@
     "no-duplicate-header": true,
     "no-emphasis-as-header": true,
     "no-generic-link-text": true,
-    "no-heading-increment": true,
+    "heading-increment": true,
     "no-space-in-links": false,
     "ol-prefix": "ordered",
     "single-h1": true,

--- a/test/usage.test.js
+++ b/test/usage.test.js
@@ -17,7 +17,7 @@ describe("usage", () => {
         "no-space-in-links": false,
         "single-h1": true,
         "no-emphasis-as-header": true,
-        "no-heading-increment": true,
+        "heading-increment": true,
         "no-generic-link-text": true,
         "ul-style": {
           style: "asterisk",


### PR DESCRIPTION
We have `"no-heading-increment": true` in the JSON file, but the [actual rule name](https://github.com/DavidAnson/markdownlint/blob/main/doc/md001.md) is `heading-increment`. This PR fixes the typo.