### PR TITLE
Give a code sample with more context for package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,10 @@ See [`markdownlint` rules](https://github.com/DavidAnson/markdownlint#rules--ali
 
 3. Add/modify your linting script in `package.json`.
 
-    ```bash
-     markdownlint-cli2 \"**/*.{md,mdx}\" \"!node_modules\"
+    ```json
+    "scripts": {
+      "lint:markdown": "markdownlint-cli2 \"**/*.{md,mdx}\" \"!node_modules\""
+    }
     ```
 
 4. Edit `.markdownlint-cli2.cjs` file to suit your needs. Start with


### PR DESCRIPTION
For developers who don't normally work on node projects, just having the command to invoke doesn't provide enough context as to how to update `package.json`. This change provides a fuller example with more context.