### PR TITLE
Fix bug where images within code blocks are being flagged

### DIFF
--- a/test/no-default-alt-text.test.js
+++ b/test/no-default-alt-text.test.js
@@ -5,6 +5,8 @@ describe("GH001: No Default Alt Text", () => {
   describe("successes", () => {
     test("inline", async () => {
       const strings = [
+        "```![image](https://user-images.githubusercontent.com/abcdef.png)```",
+        "`![Image](https://user-images.githubusercontent.com/abcdef.png)`",
         "![Chart with a single root node reading 'Example'](https://user-images.githubusercontent.com/abcdef.png)",
       ];
 


### PR DESCRIPTION
Relates to: https://github.com/github/accessibility-alt-text-bot/pull/33

Currently, this lint rule flags images within code blocks/


This PR updates the rule to make use of the AST by filtering the relevant tokens, and regex match against those tokens instead of just line regex matching.

I used the debug tab of [markdown-it](https://markdown-it.github.io/) to view the AST.



