### PR TITLE
Update and add more test coverage for `no-default-alt-text`

### DIFF
--- a/src/rules/no-default-alt-text.js
+++ b/src/rules/no-default-alt-text.js
@@ -23,7 +23,12 @@ module.exports = {
   function: function GH001(params, onError) {
     const htmlTagsWithImages = params.parsers.markdownit.tokens.filter(
       (token) => {
-        return token.type === "html_block" && token.content.includes("<img");
+        return (
+          (token.type === "html_block" && token.content.includes("<img")) ||
+          (token.type === "inline" &&
+            token.content.includes("<img") &&
+            token.children.some((child) => child.type === "html_inline"))
+        );
       },
     );
     const inlineImages = params.parsers.markdownit.tokens.filter(
@@ -36,12 +41,15 @@ module.exports = {
       const lineRange = token.map;
       const lineNumber = token.lineNumber;
       const lines = params.lines.slice(lineRange[0], lineRange[1]);
-
       for (let i = 0; i < lines.length; i++) {
         const line = lines[i];
         let matches;
         if (token.type === "inline") {
-          matches = line.matchAll(markdownAltRegex);
+          if (token.children.some((child) => child.type === "html_inline")) {
+            matches = line.matchAll(htmlAltRegex);
+          } else {
+            matches = line.matchAll(markdownAltRegex);
+          }
         } else {
           matches = line.matchAll(htmlAltRegex);
         }

--- a/src/rules/no-default-alt-text.js
+++ b/src/rules/no-default-alt-text.js
@@ -59,6 +59,7 @@ module.exports = {
           onError({
             lineNumber: lineNumber + i,
             range: [startIndex + 1, altText.length],
+            detail: `Flagged alt: ${altText}`,
           });
         }
       }

--- a/test/accessibility-rules.test.js
+++ b/test/accessibility-rules.test.js
@@ -26,7 +26,7 @@ describe("when A11y rules applied", () => {
       .map((failure) => failure.ruleNames)
       .flat();
 
-    expect(failuresForExampleFile).toHaveLength(1);
+    expect(failuresForExampleFile).toHaveLength(3);
     expect(failureNames).toContain("no-default-alt-text");
   });
 });

--- a/test/example.md
+++ b/test/example.md
@@ -1,3 +1,5 @@
 # Example Violations
 
 ![Screen Shot 2022-06-26 at 7 41 30 PM](https://user-images.githubusercontent.com/abcdef.png)
+
+<img alt="image"><img alt="Image">

--- a/test/no-default-alt-text.test.js
+++ b/test/no-default-alt-text.test.js
@@ -71,6 +71,17 @@ describe("GH001: No Default Alt Text", () => {
       }
     });
 
+    test("flags multiple consecutive inline images", async () => {
+      const strings = ['<img alt="image"><img alt="Image">'];
+      const results = await runTest(strings, altTextRule);
+      expect(results).toHaveLength(2);
+
+      expect(results[0].errorRange).toEqual([11, 5]);
+      expect(results[0].errorDetail).toEqual("Flagged alt: image");
+      expect(results[1].errorRange).toEqual([28, 5]);
+      expect(results[1].errorDetail).toEqual("Flagged alt: Image");
+    });
+
     test("error message", async () => {
       const strings = [
         "![Screen Shot 2022-06-26 at 7 41 30 PM](https://user-images.githubusercontent.com/abcdef.png)",

--- a/test/no-default-alt-text.test.js
+++ b/test/no-default-alt-text.test.js
@@ -11,10 +11,7 @@ describe("GH001: No Default Alt Text", () => {
       ];
 
       const results = await runTest(strings, altTextRule);
-
-      for (const result of results) {
-        expect(result).not.toBeDefined();
-      }
+      expect(results.length).toBe(0);
     });
     test("html image", async () => {
       const strings = [
@@ -22,10 +19,7 @@ describe("GH001: No Default Alt Text", () => {
       ];
 
       const results = await runTest(strings, altTextRule);
-
-      for (const result of results) {
-        expect(result).not.toBeDefined();
-      }
+      expect(results.length).toBe(0);
     });
   });
   describe("failures", () => {

--- a/test/no-generic-link-text.test.js
+++ b/test/no-generic-link-text.test.js
@@ -17,10 +17,7 @@ describe("GH002: No Generic Link Text", () => {
       ];
 
       const results = await runTest(strings, noGenericLinkTextRule);
-
-      for (const result of results) {
-        expect(result).not.toBeDefined();
-      }
+      expect(results.length).toBe(0);
     });
   });
   describe("failures", () => {

--- a/test/utils/run-test.js
+++ b/test/utils/run-test.js
@@ -11,7 +11,7 @@ async function runTest(strings, rule, ruleConfig) {
     customRules: [rule],
   };
 
-  return await Promise.all(
+  const results = await Promise.all(
     strings.map((variation) => {
       const thisTestConfig = {
         ...config,
@@ -21,11 +21,13 @@ async function runTest(strings, rule, ruleConfig) {
       return new Promise((resolve, reject) => {
         markdownlint(thisTestConfig, (err, result) => {
           if (err) reject(err);
-          resolve(result[0][0]);
+          resolve(result[0]);
         });
       });
     }),
   );
+
+  return results.flat();
 }
 
 exports.runTest = runTest;


### PR DESCRIPTION
In https://github.com/github/markdownlint-github/pull/83, we refactored the rule so we don't rely entirely on Regex for parsing, which was causing the rule to flag images within code blocks. (Edit: Like https://github.com/github/markdownlint-github/pull/84#issuecomment-1750683661)

This is a follow-up to that change. I noticed the rule was not correctly flagging the case where there are two images like so:

```
<img alt="image"/><img alt="image" />
```

This PR makes a few updates:

* Added `detail` to include the alt that is being flagged.
* Add test coverage and support for when there are multiple image tags in one line.
* Right now, the test helper  doesn't account for how there can be multiple violations in one line. I slightly refactored it so it does, and made subsequent updates in files.