### PR TITLE
Update no-empty-alt-text to check for no alt

### DIFF
--- a/src/rules/no-empty-alt-text.js
+++ b/src/rules/no-empty-alt-text.js
@@ -17,21 +17,30 @@ module.exports = {
       },
     );
 
-    const htmlAltRegex = new RegExp(/alt=['"]['"]/, "gid");
-
+    const htmlAltRegex = new RegExp(/alt=['"]/, "gid");
+    const htmlEmptyAltRegex = new RegExp(/alt=['"]['"]/, "gid");
     for (const token of htmlTagsWithImages) {
       const lineRange = token.map;
       const lineNumber = token.lineNumber;
       const lines = params.lines.slice(lineRange[0], lineRange[1]);
 
       for (const [i, line] of lines.entries()) {
-        const matches = line.matchAll(htmlAltRegex);
+        const noAlt = [...line.matchAll(htmlAltRegex)].length === 0;
+
+        const matches = line.matchAll(htmlEmptyAltRegex);
+
         for (const match of matches) {
           const matchingContent = match[0];
           const startIndex = match.indices[0][0];
           onError({
             lineNumber: lineNumber + i,
             range: [startIndex + 1, matchingContent.length],
+          });
+        }
+
+        if (noAlt) {
+          onError({
+            lineNumber: lineNumber + i,
           });
         }
       }

--- a/src/rules/no-empty-alt-text.js
+++ b/src/rules/no-empty-alt-text.js
@@ -1,4 +1,4 @@
-//  TODO: Clean up when https://github.com/DavidAnson/markdownlint/pull/993 is merged 
+//  TODO: Clean up when https://github.com/DavidAnson/markdownlint/pull/993 is merged
 module.exports = {
   names: ["GH003", "no-empty-alt-text"],
   description: "Please provide an alternative text for the image.",

--- a/src/rules/no-empty-alt-text.js
+++ b/src/rules/no-empty-alt-text.js
@@ -1,3 +1,4 @@
+//  TODO: Clean up when https://github.com/DavidAnson/markdownlint/pull/993 is merged 
 module.exports = {
   names: ["GH003", "no-empty-alt-text"],
   description: "Please provide an alternative text for the image.",

--- a/test/no-empty-alt-text.test.js
+++ b/test/no-empty-alt-text.test.js
@@ -21,6 +21,7 @@ describe("GH003: No Empty Alt Text", () => {
         '<img src="cat.png" alt="" /> <img src="dog.png" alt="" />',
         '<img src="dog.png" />',
         '<img alt src="dog.png" />',
+        "<img alt><img alt>",
       ];
 
       const results = await runTest(strings, noEmptyStringAltRule);
@@ -30,7 +31,7 @@ describe("GH003: No Empty Alt Text", () => {
         .flat()
         .filter((name) => !name.includes("GH"));
 
-      expect(failedRules).toHaveLength(6);
+      expect(failedRules).toHaveLength(8);
       for (const rule of failedRules) {
         expect(rule).toBe("no-empty-alt-text");
       }

--- a/test/no-empty-alt-text.test.js
+++ b/test/no-empty-alt-text.test.js
@@ -19,6 +19,8 @@ describe("GH003: No Empty Alt Text", () => {
         '<img alt="" src="https://user-images.githubusercontent.com/abcdef.png">',
         "<img alt='' src='https://user-images.githubusercontent.com/abcdef.png'>",
         '<img src="cat.png" alt="" /> <img src="dog.png" alt="" />',
+        '<img src="dog.png" />',
+        '<img alt src="dog.png" />',
       ];
 
       const results = await runTest(strings, noEmptyStringAltRule);
@@ -28,7 +30,7 @@ describe("GH003: No Empty Alt Text", () => {
         .flat()
         .filter((name) => !name.includes("GH"));
 
-      expect(failedRules).toHaveLength(4);
+      expect(failedRules).toHaveLength(6);
       for (const rule of failedRules) {
         expect(rule).toBe("no-empty-alt-text");
       }


### PR DESCRIPTION
### What


Update  `no-empty-alt-text`  to account for two additional cases
- `<img alt src=''/>`
- `<img src=''/>`