### PR TITLE
Chore: cleanup redundant alt attribute check

### DIFF
--- a/src/rules/no-empty-alt-text.js
+++ b/src/rules/no-empty-alt-text.js
@@ -19,7 +19,6 @@ module.exports = {
     );
 
     const ImageRegex = new RegExp(/<img(.*?)>/, "gid");
-    const htmlAltRegex = new RegExp(/alt=['"]/, "gid");
     const htmlEmptyAltRegex = new RegExp(/alt=['"]['"]/, "gid");
     for (const token of htmlTagsWithImages) {
       const lineRange = token.map;
@@ -35,19 +34,12 @@ module.exports = {
           const emptyAltMatches = [
             ...imageTag[0].matchAll(htmlEmptyAltRegex),
           ][0];
-          const noAltMatches = [...imageTag[0].matchAll(htmlAltRegex)];
-
           if (emptyAltMatches) {
             const matchingContent = emptyAltMatches[0];
             const startIndex = emptyAltMatches.indices[0][0];
             onError({
               lineNumber: lineNumber + i,
               range: [imageTagIndex + startIndex + 1, matchingContent.length],
-            });
-          } else if (noAltMatches.length === 0) {
-            onError({
-              lineNumber: lineNumber + i,
-              range: [imageTagIndex + 1, imageTag[0].length],
             });
           }
         }

--- a/src/rules/no-empty-alt-text.js
+++ b/src/rules/no-empty-alt-text.js
@@ -1,4 +1,3 @@
-//  TODO: Clean up when https://github.com/DavidAnson/markdownlint/pull/993 is merged
 module.exports = {
   names: ["GH003", "no-empty-alt-text"],
   description: "Please provide an alternative text for the image.",

--- a/test/no-empty-alt-text.test.js
+++ b/test/no-empty-alt-text.test.js
@@ -20,8 +20,6 @@ describe("GH003: No Empty Alt Text", () => {
         "<img alt='' src='https://user-images.githubusercontent.com/abcdef.png'>",
         '<img src="cat.png" alt="" /> <img src="dog.png" alt="" />',
         '<img src="dog.png" />',
-        '<img alt src="dog.png" />',
-        "<img alt><img alt>",
       ];
 
       const results = await runTest(strings, noEmptyStringAltRule);
@@ -31,7 +29,7 @@ describe("GH003: No Empty Alt Text", () => {
         .flat()
         .filter((name) => !name.includes("GH"));
 
-      expect(failedRules).toHaveLength(8);
+      expect(failedRules).toHaveLength(4);
       for (const rule of failedRules) {
         expect(rule).toBe("no-empty-alt-text");
       }

--- a/test/no-empty-alt-text.test.js
+++ b/test/no-empty-alt-text.test.js
@@ -19,11 +19,9 @@ describe("GH003: No Empty Alt Text", () => {
         '<img alt="" src="https://user-images.githubusercontent.com/abcdef.png">',
         "<img alt='' src='https://user-images.githubusercontent.com/abcdef.png'>",
         '<img src="cat.png" alt="" /> <img src="dog.png" alt="" />',
-        '<img src="dog.png" />',
       ];
 
       const results = await runTest(strings, noEmptyStringAltRule);
-
       const failedRules = results
         .map((result) => result.ruleNames)
         .flat()


### PR DESCRIPTION
The custom rule `no-empty-alt-text` was updated in https://github.com/github/markdownlint-github/pull/88 to temporarily support flagging images with missing alt attributes since it wasn't already handled by the native markdownlint rule `no-alt-text`.

```html
<img />
```

https://github.com/DavidAnson/markdownlint/pull/993 introduced this missing alt attribute check natively to the `no-alt-text` rule. This change  has shipped as part of markdownlint 0.33.0 which this library currently runs, so we should be able to get rid of this now-redundant check.