### PR TITLE
Fix link to GH003

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The following are custom rules defined in this plugin.
 
 * [**GH001** _no-default-alt-text_](./docs/rules/GH001-no-default-alt-text.md)
 * [**GH002** _no-generic-link-text_](./docs/rules/GH002-no-generic-link-text.md)
-* [**GH002** _no-empty-alt-text_](./docs/rules/GH002-no-empty-alt-text.md)
+* [**GH003** _no-empty-alt-text_](./docs/rules/GH003-no-empty-alt-text.md)
 
 See [`markdownlint` rules](https://github.com/DavidAnson/markdownlint#rules--aliases) for documentation on rules pulled in from `markdownlint`.
 


### PR DESCRIPTION
Added in #85, linked from README as `GH002*` instead of `GH003*`