### PR TITLE
Ensure no-default-alt-text tests against Screencast

### DIFF
--- a/src/rules/no-default-alt-text.js
+++ b/src/rules/no-default-alt-text.js
@@ -3,9 +3,10 @@
  * * "Screen Shot 2020-10-20 at 2 52 27 PM"
  * * "Screenshot 2020-10-20 at 2 52 27 PM"
  * * "Clean Shot 2020-10-20 @45x"
+ * * "Screencast from 23 02 2024 19 15 19]"
  */
 const defaultScreenshotRegex =
-  "(?:screen|clean) ?shot \\d{4}-\\d{2}-\\d{2}[^'\"\\]]*";
+  "(?:screen|clean) ?(?:shot|cast) \\d{4}-\\d{2}-\\d{2}[^'\"\\]]*";
 
 const imageRegex = "image";
 const combinedRegex = `(${[defaultScreenshotRegex, imageRegex].join("|")})`;

--- a/test/no-default-alt-text.test.js
+++ b/test/no-default-alt-text.test.js
@@ -26,6 +26,7 @@ describe("GH001: No Default Alt Text", () => {
     test("markdown example", async () => {
       const strings = [
         "![Screen Shot 2022-06-26 at 7 41 30 PM](https://user-images.githubusercontent.com/abcdef.png)",
+        "![Screencast from 23 02 2024 19 15 19](https://user-images.githubusercontent.com/abcdef.png)",
         "![ScreenShot 2022-06-26 at 7 41 30 PM](https://user-images.githubusercontent.com/abcdef.png)",
         "![Screen shot 2022-06-26 at 7 41 30 PM](https://user-images.githubusercontent.com/abcdef.png)",
         "![Screenshot 2022-06-26 at 7 41 30 PM](https://user-images.githubusercontent.com/abcdef.png)",
@@ -50,6 +51,7 @@ describe("GH001: No Default Alt Text", () => {
     test("HTML example", async () => {
       const strings = [
         '<img alt="Screen Shot 2022-06-26 at 7 41 30 PM" src="https://user-images.githubusercontent.com/abcdef.png">',
+        '<img alt=" Screencast from 23 02 2024 19 15 19" src="https://user-images.githubusercontent.com/abcdef.png">',
         '<img alt="ScreenShot 2022-06-26 at 7 41 30 PM" src="https://user-images.githubusercontent.com/abcdef.png">',
         '<img alt="Screen shot 2022-06-26 at 7 41 30 PM" src="https://user-images.githubusercontent.com/abcdef.png">',
         '<img alt="Screenshot 2022-06-26 at 7 41 30 PM" src="https://user-images.githubusercontent.com/abcdef.png">',


### PR DESCRIPTION
### What

An [issue was reported in the accessibility-alt-text-bot](https://github.com/github/accessibility-alt-text-bot/issues/47) that we did not cover The screencast use case for example: "Screencast from 23 02 2024 19 15 19".
