### PR TITLE
Replace deprecated -header rules with original -heading rules

### DIFF
--- a/.markdownlint-cli2.cjs
+++ b/.markdownlint-cli2.cjs
@@ -3,7 +3,7 @@ const options = require('./index.js').init({
     "heading-increment": true,
     "no-alt-text": true,
     "single-h1": true,
-    "no-emphasis-as-header": true,
+    "no-emphasis-as-heading": true,
     "first-line-heading": true
 })
 module.exports = {

--- a/style/accessibility.json
+++ b/style/accessibility.json
@@ -1,8 +1,8 @@
 {
     "no-alt-text": true,
     "no-default-alt-text": true,
-    "no-duplicate-header": true,
-    "no-emphasis-as-header": true,
+    "no-duplicate-heading": true,
+    "no-emphasis-as-heading": true,
     "no-generic-link-text": true,
     "heading-increment": true,
     "no-space-in-links": false,

--- a/test/usage.test.js
+++ b/test/usage.test.js
@@ -15,11 +15,11 @@ describe("usage", () => {
     test("default options returned with no arguments provided", () => {
       const options = githubMarkdownLint.init();
       expect(options).toEqual({
-        "no-duplicate-header": true,
+        "no-duplicate-heading": true,
         "ol-prefix": "ordered",
         "no-space-in-links": false,
         "single-h1": true,
-        "no-emphasis-as-header": true,
+        "no-emphasis-as-heading": true,
         "no-empty-alt-text": false,
         "heading-increment": true,
         "no-generic-link-text": true,


### PR DESCRIPTION
Resolves https://github.com/github/markdownlint-github/issues/109

As the issue describes in more detail, the `-header` aliases were deprecated in `markdownlint-cli2@v0.9.0`. Since we rely on a newer version, this change replaces the now unsupported `-header` rules with their original `-heading` counterparts. 