### PR TITLE
Add permissions to markdownlint workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,7 @@
 name: Run linter and tests
+permissions:
+  contents: read
+  pull-requests: write
 on:
   push:
     branches:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,7 @@
 name: Publish
-
+permissions:
+  contents: read
+  pull-requests: write
 on:
   release:
     types: [created]


### PR DESCRIPTION
### What 

We got a security notice that the `ci` and `publish` workflow should limit their permissions.

closes: https://github.com/github/vuln-mgmt/issues/119275