### PR TITLE
fix: Use Node.js 20 in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
           registry-url: https://registry.npmjs.org/
           cache: npm
       - run: npm ci


### PR DESCRIPTION
Node.js 16 has been end-of-life’d for more than a year. This PR updates the publish workflow to use Node.js 20, the Active LTS, instead.

https://github.com/github/markdownlint-github/pull/117 updated a package so that `structuredClone` is now called. That API did not exist in Node.js 16, so updating to a newer version avoids workflow failures.