### PR TITLE
Upgrade node to 22 and add provenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 19
+          node-version: 22
       - run: npm install
       - run: npm test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,7 @@ name: Publish
 permissions:
   contents: read
   pull-requests: write
+  id-token: write
 on:
   release:
     types: [created]
@@ -13,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org/
           cache: npm
       - run: npm ci
@@ -23,6 +24,6 @@ jobs:
           npm version ${TAG_NAME} --git-tag-version=false
         env:
           TAG_NAME: ${{github.event.release.tag_name}}
-      - run: npm whoami; npm --ignore-scripts publish
+      - run: npm whoami; npm --ignore-scripts publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
Doing some actions maintenance:

- Updated to Node 22 as it will be [LTS by the end of the month](https://github.com/nodejs/Release?tab=readme-ov-file#release-schedule)
- Set explicit permissions in all actions
- Enabled [provenance](https://docs.npmjs.com/generating-provenance-statements) when publishing to npm