### PR TITLE
chore: group dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,17 +4,23 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    group:
+    groups:
       all-dependencies:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
     open-pull-requests-limit: 99
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
       interval: weekly
     open-pull-requests-limit: 99
-    group:
+    groups:
       all-dependencies:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,17 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    group:
+      all-dependencies:
+        patterns:
+          - "*"
     open-pull-requests-limit: 99
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
       interval: weekly
     open-pull-requests-limit: 99
+    group:
+      all-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
This PR attempts to save clicks for FR by grouping minor/major dependabot updates together. The idea is that minor/major dependabot updates are less likely to contain breaking changes, and the major changes will be opened as its own PR. If this config doesn't work for the team, we can revert it or adjust it!