### PR TITLE
Temp block ESLint major version bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    # TODO: Allow `eslint` to update to version 10 after `eslint-plugin-github` updates with support for v10 too
+    ignore:
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
     groups:
       all-dependencies:
         patterns:


### PR DESCRIPTION
`eslint-plugin-github` doesn't support v10 yet, so we are blocking major bumps until then.

[More context](https://github.com/github/axe-github/pull/304#issuecomment-4143233911)