### PR TITLE
Allow Dependabot to update `eslint-plugin-github`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    # TODO: Allow `eslint` to update to version 10 after `eslint-plugin-github` updates with support for v10 too
-    ignore:
-      - dependency-name: "eslint"
-        update-types: ["version-update:semver-major"]
     groups:
       all-dependencies:
         patterns:


### PR DESCRIPTION
It supports ESLint 10 now: https://github.com/github/eslint-plugin-github/commit/fe11575a216b55df333dd154da0f59f2fc1415ca